### PR TITLE
modify - throw_if template function to support c++17

### DIFF
--- a/include/util/throw_if.hpp
+++ b/include/util/throw_if.hpp
@@ -6,15 +6,28 @@
 
 #include <stdexcept>
 #include <string>
-#include <concepts>
 #include <utility>
+
+#include "config/config.hpp"
+#include "util/util.hpp"
 
 namespace util {
 
-template<typename T>
-concept OneOfException = std::is_base_of_v<std::exception, T>;
+#ifdef __cpp_concepts
+template <typename T>
+concept one_of_exception = std::is_base_of_v<std::exception, T>;
+#else
+template <typename T>
+STATIC_CONSTEXPR bool const is_exception = std::is_base_of_v<std::exception, T>;
+#endif
 
-template <OneOfException T>
+#ifdef __cpp_concepts
+#  define TEMPLATE_HEAD_THROW_IF template <one_of_exception T>
+#else
+#  define TEMPLATE_HEAD_THROW_IF template <typename T, util::if_nullp_c<is_exception<T>> * = nullptr>
+#endif
+
+TEMPLATE_HEAD_THROW_IF
 void throw_if( bool const throw_condition, std::string const &error_message ) {
   if ( throw_condition ) {
     throw T( error_message );


### PR DESCRIPTION
Previously, the throw_if template function only supported C++20. Because I was using the concepts library. However, it wasn't until C++20 that the concepts library entered the standard.

So we added a preprocessor and templates so that we can do something similar to concepts in C++17.