### PR TITLE
Bugfix/branch

### DIFF
--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -52,10 +52,10 @@ public:
   TEMPLATE_HEAD_BRANCH
   friend inline branch operator+( branch const &lhs, T const &rhs ) noexcept { return branch( lhs ) += rhs; }
 
-  friend inline constexpr bool operator==( branch const &lhs, branch const &rhs ) noexcept {
+  friend inline bool operator==( branch const &lhs, branch const &rhs ) noexcept {
     return lhs.to_string() == rhs.to_string();
   }
-  friend inline constexpr bool operator!=( branch const &lhs, branch const &rhs ) noexcept { return !( lhs == rhs ); }
+  friend inline bool operator!=( branch const &lhs, branch const &rhs ) noexcept { return !( lhs == rhs ); }
 
 private:
   std::string path_element_;


### PR DESCRIPTION
Because I misunderstood the meaning that std::string supported constexpr, I ended up writing an ill-formed function.  A constexpr-qualified std::string should be fully freed at the end of compilation, but my code didn't. Therefore, I got an error when compiling with gcc.

refference: https://stackoverflow.com/questions/69498115/c20-constexpr-vector-and-string-not-working