### PR TITLE
Bugfix/cmake for gcc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories( ${OUTPUT} PUBLIC ${INCLUDE_DIRECTORY} )
 # MSVCとgcc系のコンパイラでは、オプションの指定方法が違うので、
 # それに対応するためにジェネレータ式を利用している。
 set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
+set( clang_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang>" )
 set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
 set( warning_options_for_clang_like -Wall -Wextra -Wshadow -Wformat=2 -Wunused )
 set( warning_options_for_msvc -W3 )
@@ -29,22 +30,21 @@ if(MINGW)
   # -target x86_64-w64-windows-gnuというオプションが
   # windows上のすべての環境に必要なのかどうかが分からないので、
   # とりあえずMSYS2環境では有効となるようにしている。
-  set( target_if_msys2 -target x86_64-w64-windows-gnu )
+  set( target_if_msys2 $<${clang_cxx}:-target x86_64-w64-windows-gnu> )
 endif()
 
 # slib : command line argument
 set_target_properties(${OUTPUT} PROPERTIES
-  STANDARD_LIBRARY $<$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>:${slib}>
+  STANDARD_LIBRARY $<$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang>:-stdlib=${slib}>
 )
 
 set( stdlib $<TARGET_GENEX_EVAL:${OUTPUT},$<TARGET_PROPERTY:${OUTPUT},STANDARD_LIBRARY>> )
-set( stdlib_option -stdlib=${stdlib} )
 message( STATUS "used standard library: ${slib}" )
 
 target_compile_options(${OUTPUT} PUBLIC
   ${warning_options}
   ${stdlib_option}
-  "${target_if_msys2}"
+  ${target_if_msys2}
 )
 
 target_link_options(${OUTPUT} PUBLIC
@@ -52,7 +52,7 @@ target_link_options(${OUTPUT} PUBLIC
 )
 
 # C++標準規格の指定 cxx_std_20はcmake3.12以降で指定可能
-target_compile_features( ${OUTPUT} PUBLIC cxx_std_20 )
+target_compile_features( ${OUTPUT} PUBLIC cxx_std_17 )
 
 ##############################
 # バージョン情報を定義したヘッダファイルを生成する

--- a/test/AddTestHelpers.cmake
+++ b/test/AddTestHelpers.cmake
@@ -31,16 +31,17 @@ function( create_test_case TEST_SOURCE_RELATIVE_PATH )
 
   # コンパイルフラグを追加
   set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
+  set( clang_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang>" )
   set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
   set( target_if_msys2 "" )
 
   if(MINGW)
-    set( target_if_msys2 "-target x86_64-w64-windows-gnu" )
+    set( target_if_msys2 $<${clang_cxx}:-target x86_64-w64-windows-gnu> )
   endif()
 
   target_compile_options(${TEST_NAME} PUBLIC
     $<${gcc_like_cxx}:-Wall -Wextra -Wshadow -Wformat=2 -Wunused> 
-    "$<${msvc_cxx}:-W3>"
+    $<${msvc_cxx}:-W3>
     ${target_if_msys2}
   )
 


### PR DESCRIPTION
The --target x86_64-w64-windows-gnu option is required when compiling with clang on MSYS2, but gcc did not. If that option is attached when compiling with gcc, an error will occur.

Therefore, the option is added only when compilation is performed on MSYS2 and clang is used.