### PR TITLE
Refac/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required( VERSION 3.22.1 )
 
 # プロジェクト名と使用する言語を指定
 project( crep LANGUAGES CXX )
+set( CMAKE_CXX_STANDARD 17 )
 
 # compile_commands.jsonを出力するように設定
 set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )

--- a/cmake/compile_option.cmake
+++ b/cmake/compile_option.cmake
@@ -1,0 +1,37 @@
+set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
+set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
+set( warning_options_for_clang_like -Wall -Wextra -Wshadow -Wformat=2 -Wunused )
+set( warning_options_for_msvc -W3 )
+set( warning_options
+  $<${gcc_like_cxx}:${warning_options_for_clang_like}>
+  $<${msvc_cxx}:${warning_options_for_msvc}>
+)
+
+set( target_if_msys2 "" )
+
+if(MINGW)
+  # -target x86_64-w64-windows-gnuというオプションが
+  # windows上のすべての環境に必要なのかどうかが分からないので、
+  # とりあえずMSYS2環境では有効となるようにしている。
+  set( target_if_msys2 -target x86_64-w64-windows-gnu )
+endif()
+
+function( add_compile_option TARGET_NAME )
+  # slib : command line argument
+  set_target_properties(${TARGET_NAME} PROPERTIES
+    STANDARD_LIBRARY $<$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>:-stdlib=${slib}>
+  )
+
+  set( stdlib $<TARGET_GENEX_EVAL:${TARGET_NAME},$<TARGET_PROPERTY:${TARGET_NAME},STANDARD_LIBRARY>> )
+  message( STATUS "used standard library: ${slib}" )
+
+  target_compile_options(${TARGET_NAME} PUBLIC
+    ${warning_options}
+    ${stdlib_option}
+    ${target_if_msys2}
+  )
+
+  target_link_options(${TARGET_NAME} PUBLIC
+    ${stdlib_option}
+  )
+endfunction( add_compile_option )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,45 +14,12 @@ target_include_directories( ${OUTPUT} PUBLIC ${INCLUDE_DIRECTORY} )
 # コンパイルフラグを追加
 # MSVCとgcc系のコンパイラでは、オプションの指定方法が違うので、
 # それに対応するためにジェネレータ式を利用している。
-set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
-set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
-set( warning_options_for_clang_like -Wall -Wextra -Wshadow -Wformat=2 -Wunused )
-set( warning_options_for_msvc -W3 )
-set( warning_options
-  $<${gcc_like_cxx}:${warning_options_for_clang_like}>
-  $<${msvc_cxx}:${warning_options_for_msvc}>
-)
+include( ${PROJECT_SOURCE_DIR}/cmake/compile_option.cmake )
 
-set( target_if_msys2 "" )
-
-if(MINGW)
-  # -target x86_64-w64-windows-gnuというオプションが
-  # windows上のすべての環境に必要なのかどうかが分からないので、
-  # とりあえずMSYS2環境では有効となるようにしている。
-  set( target_if_msys2 -target x86_64-w64-windows-gnu )
-endif()
-
-# slib : command line argument
-set_target_properties(${OUTPUT} PROPERTIES
-  STANDARD_LIBRARY $<$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>:${slib}>
-)
-
-set( stdlib $<TARGET_GENEX_EVAL:${OUTPUT},$<TARGET_PROPERTY:${OUTPUT},STANDARD_LIBRARY>> )
-set( stdlib_option -stdlib=${stdlib} )
-message( STATUS "used standard library: ${slib}" )
-
-target_compile_options(${OUTPUT} PUBLIC
-  ${warning_options}
-  ${stdlib_option}
-  "${target_if_msys2}"
-)
-
-target_link_options(${OUTPUT} PUBLIC
-  ${stdlib_option}
-)
+add_compile_option( ${OUTPUT} )
 
 # C++標準規格の指定 cxx_std_20はcmake3.12以降で指定可能
-target_compile_features( ${OUTPUT} PUBLIC cxx_std_20 )
+target_compile_features( ${OUTPUT} PUBLIC cxx_std_17 )
 
 ##############################
 # バージョン情報を定義したヘッダファイルを生成する

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,9 +18,6 @@ include( ${PROJECT_SOURCE_DIR}/cmake/compile_option.cmake )
 
 add_compile_option( ${OUTPUT} )
 
-# C++標準規格の指定 cxx_std_20はcmake3.12以降で指定可能
-target_compile_features( ${OUTPUT} PUBLIC cxx_std_17 )
-
 ##############################
 # バージョン情報を定義したヘッダファイルを生成する
 ##############################

--- a/test/AddTestHelpers.cmake
+++ b/test/AddTestHelpers.cmake
@@ -10,6 +10,8 @@ set( DIRECTORY_REGEX ".+/" )
 
 set( INCLUDE_DIRECTORY ${PROJECT_SOURCE_DIR}/include )
 
+include( ${PROJECT_SOURCE_DIR}/cmake/compile_option.cmake )
+
 ##############################
 ## テストケースを追加するための関数
 ##############################
@@ -30,19 +32,7 @@ function( create_test_case TEST_SOURCE_RELATIVE_PATH )
   target_include_directories( ${TEST_NAME} PUBLIC ${INCLUDE_DIRECTORY} )
 
   # コンパイルフラグを追加
-  set( gcc_like_cxx "$<COMPILE_LANG_AND_ID:CXX,ARMClang,AppleClang,Clang,GNU>" )
-  set( msvc_cxx "$<COMPILE_LANG_AND_ID:CXX,MSVC>" )
-  set( target_if_msys2 "" )
-
-  if(MINGW)
-    set( target_if_msys2 "-target x86_64-w64-windows-gnu" )
-  endif()
-
-  target_compile_options(${TEST_NAME} PUBLIC
-    $<${gcc_like_cxx}:-Wall -Wextra -Wshadow -Wformat=2 -Wunused> 
-    "$<${msvc_cxx}:-W3>"
-    ${target_if_msys2}
-  )
+  add_compile_option( ${TEST_NAME} )
 
   # C++標準規格の指定 cxx_std_20はcmake3.12以降で指定可能
   target_compile_features( ${TEST_NAME} PUBLIC cxx_std_20 )

--- a/test/AddTestHelpers.cmake
+++ b/test/AddTestHelpers.cmake
@@ -34,9 +34,6 @@ function( create_test_case TEST_SOURCE_RELATIVE_PATH )
   # コンパイルフラグを追加
   add_compile_option( ${TEST_NAME} )
 
-  # C++標準規格の指定 cxx_std_20はcmake3.12以降で指定可能
-  target_compile_features( ${TEST_NAME} PUBLIC cxx_std_20 )
-
   target_compile_definitions( ${TEST_NAME} PUBLIC BOOST_TEST_NO_LIB=1 )
 
   add_test(


### PR DESCRIPTION
## English
### Modification
Scripts that specify compile options and scripts that specify standards now meet the DRY principle.

### Background
There is no need to explain the harmful effects of not meeting the DRY principle. But with this change, it's no longer possible to separate the standard for compiling code for release from the standard for compiling code for testing. Let me explain this.

I believe that compiling test cases should adopt the same standards as compiling source code for release. This is because test cases can be said to be "tests" only when various assumptions are in the same state. If the premise is broken, for example, because the standards are different, I don't know if it really means "testing".

Therefore, I made it possible to change both the standard for compiling release code and the standard for compiling test code at the same time with a single change.

## 日本語(Original)
### 変更点
コンパイルオプションを指定するスクリプトと、標準規格を指定するスクリプトがDRY原則を満たすようにした。

### 背景
DRY原則を満たさないことの弊害についてはわざわざ説明する必要もないだろう。しかし今回の変更によって、リリース用のコードをコンパイルするときの標準規格とテスト用のコードをコンパイルするときの標準規格を別にすることができなくなった。これについて説明はしておこう。

私はテストケースをコンパイルするときは、リリース用のソースコードをコンパイルするのと同じ標準規格を採用すべきだと考えている。なぜなら、テストケースとは様々な前提が同じ状態である状況でこそ、「テスト」と言えるからだ。もしも例えば標準規格が違うなどのように前提が崩れていたら、それは本当に「テスト」を行ったことになるのかどうか分からない。

そのため、一か所の変更でリリース用のコードをコンパイルするときの標準規格とテスト用のコードをコンパイルするときの標準規格の両方を同時に変更できるようにした。