### PR TITLE
Feature/branch random access

### DIFF
--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -112,8 +112,14 @@ public:
   }
   friend inline bool operator!=( branch const &lhs, branch const &rhs ) noexcept { return !( lhs == rhs ); }
 
+  branch operator[]( std::size_t const index ) const noexcept {
+    auto i = index_[index].index();
+    auto len = index_[index].length();
+    return branch( path_element_.substr( i, len ) );
+  }
 private:
   std::string path_element_;
+  BranchIndex index_;
 
   // 不正な文字列が使われていないかどうかを調べる
   void isCorrect( std::string const & ) const;

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -67,7 +67,7 @@ public:
 private:
   std::vector<branch_token> token_sequence_;
 
-  role type_detection( std::string::const_iterator &, std::size_t const ) const noexcept;
+  role type_detection( std::string::const_iterator &, std::size_t const ) const;
   std::size_t token_length( std::string::const_iterator &, role const ) const noexcept;
 };
 

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -14,6 +14,54 @@
 
 namespace path {
 
+enum class BranchType {
+  ROOT,
+  DELIMITER,
+  BRANCH,
+
+  TYPE_NUM
+};
+
+class BranchToken {
+public:
+  explicit BranchToken() = default;
+  constexpr BranchToken( BranchType const type, std::size_t const index ) : branch_type_( type ), head_index_( index ) {}
+  constexpr BranchToken( BranchToken const & ) = default;
+  constexpr BranchToken & operator= ( BranchToken const & ) = default;
+  constexpr BranchToken( BranchToken && ) noexcept = default;
+  constexpr BranchToken & operator= ( BranchToken && ) noexcept = default;
+  ~BranchToken() = default;
+
+  constexpr BranchType type() const noexcept { return branch_type_; }
+  constexpr std::size_t index() const noexcept { return head_index_; }
+private:
+  BranchType branch_type_;
+  std::size_t head_index_;
+};
+
+class BranchIndex {
+public:
+  explicit BranchIndex() = default;
+  BranchIndex( std::string const & );
+  BranchIndex( BranchIndex const & ) = default;
+  BranchIndex & operator= ( BranchIndex const & ) = default;
+  BranchIndex( BranchIndex && ) noexcept = default;
+  BranchIndex & operator= ( BranchIndex && ) noexcept = default;
+  ~BranchIndex() = default;
+
+  BranchToken const & operator[]( std::size_t const index ) const noexcept { return token_sequence_[index]; }
+  BranchToken const & at( std::size_t const index ) const {
+    if ( index > token_sequence_.size() ) { throw std::range_error( "out of range" ); }
+    return token_sequence_[index];
+  }
+  std::size_t branch_num() const noexcept { return token_sequence_.size(); }
+private:
+  std::vector<BranchToken> token_sequence_;
+
+  BranchType type_detection( std::string::const_iterator &, std::size_t const ) const noexcept;
+  std::size_t token_length( std::string::const_iterator &, BranchType const ) const noexcept;
+};
+
 class branch;
 
 // Define conditions by concept and metafunction.

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -14,7 +14,9 @@
 
 namespace path {
 
-enum class BranchType {
+namespace detail {
+
+enum class role {
   ROOT,
   DELIMITER,
   BRANCH,
@@ -22,39 +24,39 @@ enum class BranchType {
   TYPE_NUM
 };
 
-class BranchToken {
+class branch_token {
 public:
-  explicit BranchToken() = default;
-  constexpr BranchToken( BranchType const type, std::size_t const index, std::size_t const length )
+  explicit branch_token() = default;
+  constexpr branch_token( role const type, std::size_t const index, std::size_t const length )
       : branch_type_( type ), head_index_( index ), length_( length ) {}
-  constexpr BranchToken( BranchToken const & ) = default;
-  constexpr BranchToken &operator=( BranchToken const & ) = default;
-  constexpr BranchToken( BranchToken && ) noexcept = default;
-  constexpr BranchToken &operator=( BranchToken && ) noexcept = default;
-  ~BranchToken() = default;
+  constexpr branch_token( branch_token const & ) = default;
+  constexpr branch_token &operator=( branch_token const & ) = default;
+  constexpr branch_token( branch_token && ) noexcept = default;
+  constexpr branch_token &operator=( branch_token && ) noexcept = default;
+  ~branch_token() = default;
 
-  constexpr BranchType type() const noexcept { return branch_type_; }
+  constexpr role type() const noexcept { return branch_type_; }
   constexpr std::size_t index() const noexcept { return head_index_; }
   constexpr std::size_t length() const noexcept { return length_; }
 
 private:
-  BranchType branch_type_;
+  role branch_type_;
   std::size_t head_index_;
   std::size_t length_;
 };
 
-class BranchIndex {
+class index {
 public:
-  explicit BranchIndex() = default;
-  BranchIndex( std::string const & );
-  BranchIndex( BranchIndex const & ) = default;
-  BranchIndex &operator=( BranchIndex const & ) = default;
-  BranchIndex( BranchIndex && ) noexcept = default;
-  BranchIndex &operator=( BranchIndex && ) noexcept = default;
-  ~BranchIndex() = default;
+  explicit index() = default;
+  index( std::string const & );
+  index( index const & ) = default;
+  index &operator=( index const & ) = default;
+  index( index && ) noexcept = default;
+  index &operator=( index && ) noexcept = default;
+  ~index() = default;
 
-  BranchToken const &operator[]( std::size_t const index ) const noexcept { return token_sequence_[index]; }
-  BranchToken const &at( std::size_t const index ) const {
+  branch_token const &operator[]( std::size_t const index ) const noexcept { return token_sequence_[index]; }
+  branch_token const &at( std::size_t const index ) const {
     if ( index > token_sequence_.size() ) {
       throw std::range_error( "out of range" );
     }
@@ -63,11 +65,13 @@ public:
   std::size_t branch_num() const noexcept { return token_sequence_.size(); }
 
 private:
-  std::vector<BranchToken> token_sequence_;
+  std::vector<branch_token> token_sequence_;
 
-  BranchType type_detection( std::string::const_iterator &, std::size_t const ) const noexcept;
-  std::size_t token_length( std::string::const_iterator &, BranchType const ) const noexcept;
+  role type_detection( std::string::const_iterator &, std::size_t const ) const noexcept;
+  std::size_t token_length( std::string::const_iterator &, role const ) const noexcept;
 };
+
+}  // namespace detail
 
 class branch;
 
@@ -117,9 +121,10 @@ public:
     auto len = index_[index].length();
     return branch( path_element_.substr( i, len ) );
   }
+
 private:
   std::string path_element_;
-  BranchIndex index_;
+  detail::index index_;
 
   // 不正な文字列が使われていないかどうかを調べる
   void isCorrect( std::string const & ) const;

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -25,18 +25,22 @@ enum class BranchType {
 class BranchToken {
 public:
   explicit BranchToken() = default;
-  constexpr BranchToken( BranchType const type, std::size_t const index ) : branch_type_( type ), head_index_( index ) {}
+  constexpr BranchToken( BranchType const type, std::size_t const index, std::size_t const length )
+      : branch_type_( type ), head_index_( index ), length_( length ) {}
   constexpr BranchToken( BranchToken const & ) = default;
-  constexpr BranchToken & operator= ( BranchToken const & ) = default;
+  constexpr BranchToken &operator=( BranchToken const & ) = default;
   constexpr BranchToken( BranchToken && ) noexcept = default;
-  constexpr BranchToken & operator= ( BranchToken && ) noexcept = default;
+  constexpr BranchToken &operator=( BranchToken && ) noexcept = default;
   ~BranchToken() = default;
 
   constexpr BranchType type() const noexcept { return branch_type_; }
   constexpr std::size_t index() const noexcept { return head_index_; }
+  constexpr std::size_t length() const noexcept { return length_; }
+
 private:
   BranchType branch_type_;
   std::size_t head_index_;
+  std::size_t length_;
 };
 
 class BranchIndex {
@@ -44,17 +48,20 @@ public:
   explicit BranchIndex() = default;
   BranchIndex( std::string const & );
   BranchIndex( BranchIndex const & ) = default;
-  BranchIndex & operator= ( BranchIndex const & ) = default;
+  BranchIndex &operator=( BranchIndex const & ) = default;
   BranchIndex( BranchIndex && ) noexcept = default;
-  BranchIndex & operator= ( BranchIndex && ) noexcept = default;
+  BranchIndex &operator=( BranchIndex && ) noexcept = default;
   ~BranchIndex() = default;
 
-  BranchToken const & operator[]( std::size_t const index ) const noexcept { return token_sequence_[index]; }
-  BranchToken const & at( std::size_t const index ) const {
-    if ( index > token_sequence_.size() ) { throw std::range_error( "out of range" ); }
+  BranchToken const &operator[]( std::size_t const index ) const noexcept { return token_sequence_[index]; }
+  BranchToken const &at( std::size_t const index ) const {
+    if ( index > token_sequence_.size() ) {
+      throw std::range_error( "out of range" );
+    }
     return token_sequence_[index];
   }
   std::size_t branch_num() const noexcept { return token_sequence_.size(); }
+
 private:
   std::vector<BranchToken> token_sequence_;
 

--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -1,9 +1,70 @@
 #include "path/branch.hpp"
 
+#include <iterator>
+
 #include "config/config.hpp"
 #include "util/throw_if.hpp"
 
 namespace path {
+
+BranchIndex::BranchIndex( std::string const &branch_str ) {
+  for ( std::string::const_iterator itr = branch_str.begin(); itr != branch_str.end(); ++itr ) {
+    std::size_t head_index = std::distance( branch_str.begin(), itr );
+    BranchType token_type = type_detection( itr, head_index );
+    if ( token_type != BranchType::DELIMITER ) {
+      token_sequence_.emplace_back( token_type, head_index );
+    }
+
+    switch ( token_type ) {
+      case BranchType::ROOT:
+#if _WIN32
+        ++itr;
+        continue;
+#else
+        continue;
+#endif
+        break;
+      case BranchType::DELIMITER:
+        continue;
+      case BranchType::BRANCH:
+        for ( ;; ++itr ) {
+          if ( ( *( itr + 1 ) == PATH_SEPARATOR ) || ( ( itr + 1 ) == branch_str.cend() ) ) {
+            break;
+          }
+        }
+    }
+  }
+}
+
+BranchType BranchIndex::type_detection( std::string::const_iterator &itr, std::size_t const index ) const noexcept {
+  BranchType type;
+#if _WIN32
+  // ただし、このタイプ判定が期待通りに働くためには
+  // 必ず2文字目にアクセス可能で、かつブランチの途中でこの関数が呼び出されない
+  // という条件が成り立っている必要がある。
+  // 例えばC:\\Users\\...のようなパスがあった場合、
+  // その2文字目を指すイテレータが、この関数に渡されてはいけない。
+  if ( *( itr + 1 ) == ':' ) {
+    if ( *itr >= 'A' && *itr <= 'Z' ) {
+      type = ROOT;
+    }
+  } else if ( *itr == PATH_SEPARATOR ) {
+    type = Type::DELIMITER;
+  } else {
+  }
+#else
+  if ( *itr == PATH_SEPARATOR ) {
+    if ( index == 0 ) {
+      type = BranchType::ROOT;
+    } else {
+      type = BranchType::DELIMITER;
+    }
+  } else {
+    type = BranchType::BRANCH;
+  }
+#endif
+  return type;
+}
 
 branch::branch( std::string const &path_element ) : path_element_( path_element ) { isCorrect( path_element_ ); }
 

--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -8,14 +8,16 @@
 
 namespace path {
 
-BranchIndex::BranchIndex( std::string const &branch_str ) {
+namespace detail {
+
+index::index( std::string const &branch_str ) {
   for ( std::string::const_iterator itr = branch_str.begin(); itr != branch_str.end(); ++itr ) {
     std::size_t head_index = std::distance( branch_str.begin(), itr );
-    BranchType token_type = type_detection( itr, head_index );
+    role token_type = type_detection( itr, head_index );
     std::size_t length = 0;
 
     switch ( token_type ) {
-      case BranchType::ROOT:
+      case role::ROOT:
 #if _WIN32
         length = 2;
         ++itr;
@@ -25,10 +27,10 @@ BranchIndex::BranchIndex( std::string const &branch_str ) {
         break;
 #endif
         break;
-      case BranchType::DELIMITER:
+      case role::DELIMITER:
         length = 1;
         break;
-      case BranchType::BRANCH:
+      case role::BRANCH:
         for ( ;; ++itr ) {
           ++length;
           if ( ( *( itr + 1 ) == PATH_SEPARATOR ) || ( ( itr + 1 ) == branch_str.cend() ) ) {
@@ -40,14 +42,14 @@ BranchIndex::BranchIndex( std::string const &branch_str ) {
     }
 
     std::cout << "head_index: " << head_index << std::endl;
-    if ( token_type != BranchType::DELIMITER ) {
+    if ( token_type != role::DELIMITER ) {
       token_sequence_.emplace_back( token_type, head_index, length );
     }
   }
 }
 
-BranchType BranchIndex::type_detection( std::string::const_iterator &itr, std::size_t const index ) const noexcept {
-  BranchType type;
+role index::type_detection( std::string::const_iterator &itr, std::size_t const index ) const noexcept {
+  role type;
 #if _WIN32
   // ただし、このタイプ判定が期待通りに働くためには
   // 必ず2文字目にアクセス可能で、かつブランチの途中でこの関数が呼び出されない
@@ -65,16 +67,18 @@ BranchType BranchIndex::type_detection( std::string::const_iterator &itr, std::s
 #else
   if ( *itr == PATH_SEPARATOR ) {
     if ( index == 0 ) {
-      type = BranchType::ROOT;
+      type = role::ROOT;
     } else {
-      type = BranchType::DELIMITER;
+      type = role::DELIMITER;
     }
   } else {
-    type = BranchType::BRANCH;
+    type = role::BRANCH;
   }
 #endif
   return type;
 }
+
+}  // namespace detail
 
 branch::branch( std::string const &path_element ) : path_element_( path_element ), index_( path_element ) {
   isCorrect( path_element_ );

--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -1,5 +1,6 @@
 #include "path/branch.hpp"
 
+#include <iostream>
 #include <iterator>
 
 #include "config/config.hpp"
@@ -11,27 +12,36 @@ BranchIndex::BranchIndex( std::string const &branch_str ) {
   for ( std::string::const_iterator itr = branch_str.begin(); itr != branch_str.end(); ++itr ) {
     std::size_t head_index = std::distance( branch_str.begin(), itr );
     BranchType token_type = type_detection( itr, head_index );
-    if ( token_type != BranchType::DELIMITER ) {
-      token_sequence_.emplace_back( token_type, head_index );
-    }
+    std::size_t length = 0;
 
     switch ( token_type ) {
       case BranchType::ROOT:
 #if _WIN32
+        length = 2;
         ++itr;
-        continue;
+        break;
 #else
-        continue;
+        length = 1;
+        break;
 #endif
         break;
       case BranchType::DELIMITER:
-        continue;
+        length = 1;
+        break;
       case BranchType::BRANCH:
         for ( ;; ++itr ) {
+          ++length;
           if ( ( *( itr + 1 ) == PATH_SEPARATOR ) || ( ( itr + 1 ) == branch_str.cend() ) ) {
             break;
           }
         }
+      default:
+        break;
+    }
+
+    std::cout << "head_index: " << head_index << std::endl;
+    if ( token_type != BranchType::DELIMITER ) {
+      token_sequence_.emplace_back( token_type, head_index, length );
     }
   }
 }

--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -1,6 +1,5 @@
 #include "path/branch.hpp"
 
-#include <iostream>
 #include <iterator>
 
 #include "config/config.hpp"
@@ -41,14 +40,13 @@ index::index( std::string const &branch_str ) {
         break;
     }
 
-    std::cout << "head_index: " << head_index << std::endl;
     if ( token_type != role::DELIMITER ) {
       token_sequence_.emplace_back( token_type, head_index, length );
     }
   }
 }
 
-role index::type_detection( std::string::const_iterator &itr, std::size_t const index ) const noexcept {
+role index::type_detection( std::string::const_iterator &itr, std::size_t const index ) const {
   role type;
 #if _WIN32
   // ただし、このタイプ判定が期待通りに働くためには
@@ -58,11 +56,15 @@ role index::type_detection( std::string::const_iterator &itr, std::size_t const 
   // その2文字目を指すイテレータが、この関数に渡されてはいけない。
   if ( *( itr + 1 ) == ':' ) {
     if ( *itr >= 'A' && *itr <= 'Z' ) {
-      type = ROOT;
+      type = role::ROOT;
+    } else {
+      type = role::TYPE_NUM;
+      throw std::invalid_argument( "A character was used that should not be in a branch." );
     }
   } else if ( *itr == PATH_SEPARATOR ) {
-    type = Type::DELIMITER;
+    type = role::DELIMITER;
   } else {
+    type = role::BRANCH;
   }
 #else
   if ( *itr == PATH_SEPARATOR ) {

--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -76,7 +76,9 @@ BranchType BranchIndex::type_detection( std::string::const_iterator &itr, std::s
   return type;
 }
 
-branch::branch( std::string const &path_element ) : path_element_( path_element ) { isCorrect( path_element_ ); }
+branch::branch( std::string const &path_element ) : path_element_( path_element ), index_( path_element ) {
+  isCorrect( path_element_ );
+}
 
 [[deprecated]] void branch::modify( std::function<void( std::string & )> modify_function ) {
   modify_function( path_element_ );

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -52,15 +52,40 @@ BOOST_AUTO_TEST_CASE( test_case3 ) {
 BOOST_AUTO_TEST_CASE( test_case4 ) {
   using namespace path;
   using namespace path::detail;
+  std::cout << std::endl;
 
+#if _WIN32
+  std::string absolute_path( "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua" );
+#else
   std::string absolute_path( "/usr/include/c++/11/cstdlib" );
+#endif
   detail::index arch( absolute_path );
-  BOOST_TEST( ( arch.branch_num() == 6 ) == true );
 
   branch_token token0 = arch[0];
   branch_token token1 = arch[1];
   branch_token token2 = arch[2];
   branch_token token3 = arch[3];
+
+#if _WIN32
+  BOOST_TEST( ( arch.branch_num() == 7 ) == true );
+
+  BOOST_TEST( ( token0.type() == role::ROOT ) == true );
+  BOOST_TEST( ( token0.index() == 0 ) == true );
+  BOOST_TEST( ( token0.length() == 2 ) == true );
+
+  BOOST_TEST( ( token1.type() == role::BRANCH ) == true );
+  BOOST_TEST( ( token1.index() == 3 ) == true );
+  BOOST_TEST( ( token1.length() == 5 ) == true );
+
+  BOOST_TEST( ( token2.type() == role::BRANCH ) == true );
+  BOOST_TEST( ( token2.index() == 9 ) == true );
+  BOOST_TEST( ( token2.length() == 8 ) == true );
+
+  BOOST_TEST( ( token3.type() == role::BRANCH ) == true );
+  BOOST_TEST( ( token3.index() == 18 ) == true );
+  BOOST_TEST( ( token3.length() == 7 ) == true );
+#else
+  BOOST_TEST( ( arch.branch_num() == 6 ) == true );
 
   BOOST_TEST( ( token0.type() == role::ROOT ) == true );
   BOOST_TEST( ( token0.index() == 0 ) == true );
@@ -77,11 +102,22 @@ BOOST_AUTO_TEST_CASE( test_case4 ) {
   BOOST_TEST( ( token3.type() == role::BRANCH ) == true );
   BOOST_TEST( ( token3.index() == 13 ) == true );
   BOOST_TEST( ( token3.length() == 3 ) == true );
+#endif
 }
 
 BOOST_AUTO_TEST_CASE( test_case5 ) {
   using namespace path;
 
+#if _WIN32
+  std::string absolute_path( "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua" );
+  branch b0( "C:" ), b1( "Users" ), b2( "username" ), b3( "AppData" );
+  branch b( absolute_path );
+
+  BOOST_TEST( ( b[0] == b0 ) == true );
+  BOOST_TEST( ( b[1] == b1 ) == true );
+  BOOST_TEST( ( b[2] == b2 ) == true );
+  BOOST_TEST( ( b[3] == b3 ) == true );
+#else
   std::string absolute_path( "/usr/include/c++/11/cstdlib" );
   branch b0( "/" ), b1( "usr" ), b2( "include" ), b3( "c++" );
   branch b( absolute_path );
@@ -90,6 +126,7 @@ BOOST_AUTO_TEST_CASE( test_case5 ) {
   BOOST_TEST( ( b[1] == b1 ) == true );
   BOOST_TEST( ( b[2] == b2 ) == true );
   BOOST_TEST( ( b[3] == b3 ) == true );
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -51,29 +51,30 @@ BOOST_AUTO_TEST_CASE( test_case3 ) {
 
 BOOST_AUTO_TEST_CASE( test_case4 ) {
   using namespace path;
+  using namespace path::detail;
 
   std::string absolute_path( "/usr/include/c++/11/cstdlib" );
-  BranchIndex arch( absolute_path );
+  detail::index arch( absolute_path );
   BOOST_TEST( ( arch.branch_num() == 6 ) == true );
 
-  BranchToken token0 = arch[0];
-  BranchToken token1 = arch[1];
-  BranchToken token2 = arch[2];
-  BranchToken token3 = arch[3];
+  branch_token token0 = arch[0];
+  branch_token token1 = arch[1];
+  branch_token token2 = arch[2];
+  branch_token token3 = arch[3];
 
-  BOOST_TEST( ( token0.type() == BranchType::ROOT ) == true );
+  BOOST_TEST( ( token0.type() == role::ROOT ) == true );
   BOOST_TEST( ( token0.index() == 0 ) == true );
   BOOST_TEST( ( token0.length() == 1 ) == true );
 
-  BOOST_TEST( ( token1.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token1.type() == role::BRANCH ) == true );
   BOOST_TEST( ( token1.index() == 1 ) == true );
   BOOST_TEST( ( token1.length() == 3 ) == true );
 
-  BOOST_TEST( ( token2.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token2.type() == role::BRANCH ) == true );
   BOOST_TEST( ( token2.index() == 5 ) == true );
   BOOST_TEST( ( token2.length() == 7 ) == true );
 
-  BOOST_TEST( ( token3.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token3.type() == role::BRANCH ) == true );
   BOOST_TEST( ( token3.index() == 13 ) == true );
   BOOST_TEST( ( token3.length() == 3 ) == true );
 }

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -49,6 +49,29 @@ BOOST_AUTO_TEST_CASE( test_case3 ) {
   BOOST_TEST( ( j == branch( "ab" ) ) == true );
 }
 
-BOOST_AUTO_TEST_CASE( test_case4 ) { using namespace path; }
+BOOST_AUTO_TEST_CASE( test_case4 ) {
+  using namespace path;
+
+  std::string absolute_path( "/usr/include/c++/11/cstdlib" );
+  BranchIndex arch( absolute_path );
+  BOOST_TEST( ( arch.branch_num() == 6 ) == true );
+
+  BranchToken token0 = arch[0];
+  BranchToken token1 = arch[1];
+  BranchToken token2 = arch[2];
+  BranchToken token3 = arch[3];
+
+  BOOST_TEST( ( token0.type() == BranchType::ROOT ) == true );
+  BOOST_TEST( ( token0.index() == 0 ) == true );
+
+  BOOST_TEST( ( token1.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token1.index() == 1 ) == true );
+
+  BOOST_TEST( ( token2.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token2.index() == 5 ) == true );
+
+  BOOST_TEST( ( token3.type() == BranchType::BRANCH ) == true );
+  BOOST_TEST( ( token3.index() == 13 ) == true );
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -63,15 +63,19 @@ BOOST_AUTO_TEST_CASE( test_case4 ) {
 
   BOOST_TEST( ( token0.type() == BranchType::ROOT ) == true );
   BOOST_TEST( ( token0.index() == 0 ) == true );
+  BOOST_TEST( ( token0.length() == 1 ) == true );
 
   BOOST_TEST( ( token1.type() == BranchType::BRANCH ) == true );
   BOOST_TEST( ( token1.index() == 1 ) == true );
+  BOOST_TEST( ( token1.length() == 3 ) == true );
 
   BOOST_TEST( ( token2.type() == BranchType::BRANCH ) == true );
   BOOST_TEST( ( token2.index() == 5 ) == true );
+  BOOST_TEST( ( token2.length() == 7 ) == true );
 
   BOOST_TEST( ( token3.type() == BranchType::BRANCH ) == true );
   BOOST_TEST( ( token3.index() == 13 ) == true );
+  BOOST_TEST( ( token3.length() == 3 ) == true );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -78,4 +78,17 @@ BOOST_AUTO_TEST_CASE( test_case4 ) {
   BOOST_TEST( ( token3.length() == 3 ) == true );
 }
 
+BOOST_AUTO_TEST_CASE( test_case5 ) {
+  using namespace path;
+
+  std::string absolute_path( "/usr/include/c++/11/cstdlib" );
+  branch b0( "/" ), b1( "usr" ), b2( "include" ), b3( "c++" );
+  branch b( absolute_path );
+
+  BOOST_TEST( ( b[0] == b0 ) == true );
+  BOOST_TEST( ( b[1] == b1 ) == true );
+  BOOST_TEST( ( b[2] == b2 ) == true );
+  BOOST_TEST( ( b[3] == b3 ) == true );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# English
## Background
Ultimately, I would like to be able to extract the common part or delete the common part with subbranch_exclude() etc., but I think it would be easier to implement iterators to implement those operations. So I want to implement a randomly accessible iterator.

However, until now, it was not possible to perform random access to each branch of the branch class in the first place.

## Modification
Changed the branch class to be randomly accessible.

## Concern
There is no guarantee that it will work without problems on Windows.

## How to verify concerns
Compile and run test_case4 and test_case5 of test/branch.cpp on Windows machine.

# 日本語( Original )
## Background
最終的には共通部分を抜き出したり、あるいはsubbranch_exclude()などで、共通部分を削除したりできるようにしたいのだが、それらの操作を実装するには、イテレータを実装していると楽そうだと予想した。そのため、ランダムアクセス可能なイテレータを実装したいと考えている。

しかし、今まではそもそもbranchクラスの各branchにランダムアクセスを行うことができなかった。

## 変更点
branchクラスをランダムアクセス可能となるように変更した。

## 懸念点
Windowsでも問題なく動作する保証がまだない。

## 懸念点の検証方法
test/branch.cppのtest_case4とtest_case5をWindows機上でコンパイルして実行してみる。
