### PR TITLE
Refac/branch test

### DIFF
--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -7,10 +7,10 @@
 
 #define TEST( CONDITION ) BOOST_TEST( ( CONDITION ) == true )
 #if _WIN32
-#  define TEST_PATH "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua"
+#  define TEST_ABSOLUTE_PATH "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua"
 #  define BRANCH_LIST "C:", "Users", "username", "AppData", "Local", "nvim", "init.lua"
 #else
-#  define TEST_PATH "/usr/include/c++/11/cstdlib"
+#  define TEST_ABSOLUTE_PATH "/usr/include/c++/11/cstdlib"
 #  define BRANCH_LIST "/", "usr", "include", "c++", "11", "cstdlib"
 #endif
 
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( test_case3 ) {
   using namespace path;
   std::cout << std::endl;
 
-  std::string absolute_path( TEST_PATH );
+  std::string absolute_path( TEST_ABSOLUTE_PATH );
   branch b( absolute_path );
 
   std::cout << "b.to_string(): " << b.to_string() << std::endl;

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -6,6 +6,13 @@
 #include <type_traits>
 
 #define TEST( CONDITION ) BOOST_TEST( ( CONDITION ) == true )
+#if _WIN32
+#  define TEST_PATH "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua"
+#  define BRANCH_LIST "C:", "Users", "username", "AppData", "Local", "nvim", "init.lua"
+#else
+#  define TEST_PATH "/usr/include/c++/11/cstdlib"
+#  define BRANCH_LIST "/", "usr", "include", "c++", "11", "cstdlib"
+#endif
 
 BOOST_AUTO_TEST_SUITE( test_branch )
 
@@ -48,11 +55,7 @@ BOOST_AUTO_TEST_CASE( test_case3 ) {
   using namespace path;
   std::cout << std::endl;
 
-#if _WIN32
-  std::string absolute_path( "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua" );
-#else
-  std::string absolute_path( "/usr/include/c++/11/cstdlib" );
-#endif
+  std::string absolute_path( TEST_PATH );
   branch b( absolute_path );
 
   std::cout << "b.to_string(): " << b.to_string() << std::endl;


### PR DESCRIPTION
# English
I moved the section where the path used in the branch class test and the list of branches that compose it are defined to the beginning of the file.

# Japanese( Original )
branchクラスのテストで使うパスと、それを構成するブランチのリストを定義する箇所を、ファイルの冒頭に変更した。