### PR TITLE
Bugfix/branch

### DIFF
--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -57,21 +57,13 @@ std::string branch::buildBranch() const noexcept {
     if ( citr == path_element_.cbegin() ) {
       branch_tmp += ( *citr );
       continue;
-    }
-    if ( isRoot( *citr ) == true ) {
-      branch_tmp += ( *citr );
     } else {
 #ifdef _WIN32
       branch_tmp += DELIMITER;
       branch_tmp += ( *citr );
 #elif __linux__
-      if ( citr != path_element_.cbegin() ) {
-        if ( isRoot( *( citr - 1 ) ) == true ) {
-          branch_tmp += ( *citr );
-        } else {
-          branch_tmp += DELIMITER;
-          branch_tmp += ( *citr );
-        }
+      if ( isRoot( *( citr - 1 ) ) == true ) {
+        branch_tmp += ( *citr );
       } else {
         branch_tmp += DELIMITER;
         branch_tmp += ( *citr );

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -12,9 +12,11 @@
 
 #if _WIN32
 #  define TEST_ABSOLUTE_PATH "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua"
+#  define TEST_RELATIVE_PATH ".\\build\\src\\crep"
 #  define BRANCH_LIST "C:", "Users", "username", "AppData", "Local", "nvim", "init.lua"
 #else
 #  define TEST_ABSOLUTE_PATH "/usr/include/c++/11/cstdlib"
+#  define TEST_RELATIVE_PATH "./build/src/crep"
 #  define BRANCH_LIST "/", "usr", "include", "c++", "11", "cstdlib"
 #endif
 
@@ -161,7 +163,7 @@ BOOST_AUTO_TEST_CASE( test_case5 ) {
   using namespace path;
   std::cout << std::endl;
 
-  std::string relative_path( "./build/src/crep" );
+  std::string relative_path( TEST_RELATIVE_PATH );
   branch b( relative_path );
 
   std::cout << "b.to_string(): " << b.to_string() << std::endl;

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -33,9 +33,7 @@ BOOST_AUTO_TEST_CASE( test_case2 ) {
   branch j1( "a" );
   branch const j2( "a" ), j3( "b" );
   branch const connected1( std::string( "a" ) + DELIMITER + std::string( "b" ) );
-  branch const connected2(
-      std::string( "a" ) + DELIMITER + std::string( "b" ) + DELIMITER + std::string( "c" )
-  );
+  branch const connected2( std::string( "a" ) + DELIMITER + std::string( "b" ) + DELIMITER + std::string( "c" ) );
   std::string str1( "c" );
 
   TEST( j1 == j2 );

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -159,4 +159,19 @@ BOOST_AUTO_TEST_CASE( test_case4_branch_truncate_error ) {
   BOOST_CHECK_THROW( b.truncate( branch( TRUNCATE_BRANCH ) ), std::invalid_argument );
 }
 
+BOOST_AUTO_TEST_CASE( test_case5 ) {
+  using namespace path;
+  std::cout << std::endl;
+
+  std::string relative_path( "./build/src/crep" );
+  branch b( relative_path );
+
+  std::cout << "b.to_string(): " << b.to_string() << std::endl;
+  TEST( relative_path == b.to_string() );
+  TEST( b[0] == "." );
+  TEST( b[1] == "build" );
+  TEST( b[2] == "src" );
+  TEST( b[3] == "crep" );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# English
## Background
If the branch stored in the branch class was not absolute path, the to_string() function would not return correct value. For instance, if the branch class stored the relative path"./build/src/crep", the return value from to_string() would be "/./build/src/crep".

## Change point
When the branch class build one branch by concatnating single-branches stored within it, no delimiter is placed in front of the first single-branch. Therefore, I fixeda bug in the buildBranch function by switching the process based on whether the iterator is same as path_element_.begin().

# Japanese( Original )
## 背景
branchクラスの保持しているブランチが絶対パスでなければ、to_string()関数が正しい値を返さなかった。例えば、"./build/src/crep"という相対パスを保存していた場合、to_string()関数の結果は"/./build/src/crep"となっていた。

## 変更点
branchクラスに保持されている各単ブランチを区切り文字と一緒につなげて、一つのブランチを構築するとき、最初の単ブランチの直前に区切り文字が置かれることはありえない。そのため、イテレータがpath_element_.begin()と同じかどうかで処理を分けて、buildBranch関数のバグを修正した。