### PR TITLE
Bugfix/contains

### DIFF
--- a/src/path/branch.cpp
+++ b/src/path/branch.cpp
@@ -68,7 +68,7 @@ branch::index_type branch::contains( branch const &maybe_contain ) const noexcep
   };
 
   for ( const_iterator citr = path_element_.cbegin(); citr != element_end; ++citr ) {
-    if ( maybe_contain.size() > static_cast<std::size_t>( std::distance( citr, element_end ) ) ) {
+    if ( maybe_contain.size() >= static_cast<std::size_t>( std::distance( citr, element_end ) ) ) {
       match_begin = element_end;
     }
     if ( branch_compare( citr ) ) {

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -1,5 +1,4 @@
 #include "path/branch.hpp"
-#include "iterator/index_t.hpp"
 
 #include <array>
 #include <boost/test/unit_test.hpp>
@@ -8,6 +7,8 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+
+#include "iterator/index_t.hpp"
 
 #define TEST( CONDITION ) BOOST_TEST( ( CONDITION ) == true )
 
@@ -197,9 +198,15 @@ BOOST_AUTO_TEST_CASE( test_case6_contain ) {
   std::string branch_string( TEST_RELATIVE_PATH );
   branch b( branch_string );
 
-  std::cout << "src/crep index: " << b.contains( branch( "src/crep" ) ) << std::endl;
+  std::cout << "src/crep index: " << b.contains( branch( std::string( "src" ) + DELIMITER + std::string( "crep" ) ) )
+            << std::endl;
   TEST( static_cast<std::size_t>( b.contains( branch( "crep" ) ) ) == 3 );
-  TEST( static_cast<std::size_t> ( b.contains( branch( std::string( "src" ) + DELIMITER + std::string( "crep" ) ) ) ) == 2 );
+  TEST(
+      static_cast<std::size_t>( b.contains( branch( std::string( "src" ) + DELIMITER + std::string( "crep" ) ) ) ) == 2
+  );
+  TEST(
+      static_cast<std::size_t>( b.contains( branch( std::string( "src" ) + DELIMITER + std::string( "crep" ) ) ) ) == 2
+  );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -209,4 +209,20 @@ BOOST_AUTO_TEST_CASE( test_case6_contain ) {
   );
 }
 
+BOOST_AUTO_TEST_CASE( test_case6_not_contain ) {
+  using namespace path;
+  using size_type = path::branch::index_type::value_type;
+  std::cout << std::endl;
+
+  std::string branch_string( TEST_RELATIVE_PATH );
+  branch b( branch_string );
+
+  std::cout << "not_contain index: " << b.contains( branch( "not_contain" ) ) << std::endl;
+  std::cout << "crep::npos_v: " << crep::npos_v<size_type> << std::endl;
+  std::cout << "static_cast<size_type>( crep::index_t<size_type>() ): "
+            << static_cast<size_type>( crep::index_t<size_type>() ) << std::endl;
+  TEST( static_cast<size_type>( crep::index_t<size_type>() ) == crep::npos_v<size_type> );
+  TEST( static_cast<size_type>( b.contains( branch( "not_contain" ) ) ) == crep::npos_v<size_type> );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# English
## Background
The branch::contains function did not return the correct npos when given a non-existent branch. In this software, npos is defined as the maximum value an unsigned integer type can take. Furthermore, this return value, when compared to index_t() using operator==, evaluates to true.

## Change point
I fixed the size comparison between the branch given as an argument and path_element_ that has not been compared yet.

# Japanese( Original )
## 背景
branch::containsは、存在しないブランチを与えられたとき、正しいnposを返していなかった。ここでnposは標準ライブラリ同様、符号なし整数型の取れる最大値としている。またその戻り値は、index_t()とoperator==で比較するとtrueとなるような値でもある。

## 変更点
引数で与えられたブランチと、まだ比較が済んでいないpath_element_のサイズ比較が間違っていたので修正した。