### PR TITLE
add - overload of recursive_scan_directory for path::branch

### DIFF
--- a/include/util/path.hpp
+++ b/include/util/path.hpp
@@ -4,18 +4,20 @@
 
 #pragma once
 
-#include "config/config.hpp"
-#include "util/util.hpp"
-
 #include <functional>
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <type_traits>
+
+#include "config/config.hpp"
+#include "path/branch.hpp"
+#include "util/util.hpp"
 
 namespace path {
 
-void recursive_scan_directory( std::string const &scanning_path, std::vector<std::string> &paths );
+void recursive_scan_directory( std::string const &scanning_path, std::vector<std::string> & );
 std::vector<std::string> recursive_scan_directory( std::string const &scanning_path );
+void recursive_scan_directory( path::branch const &scanning_path, std::vector<path::branch> & );
+std::vector<path::branch> recursive_scan_directory( path::branch const &scanning_path );
 
-} // path
+}  // namespace path

--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -1,9 +1,10 @@
-#include "config/config.hpp"
 #include "util/path.hpp"
-#include "util/throw_if.hpp"
 
-#include <vector>
 #include <string>
+#include <vector>
+
+#include "config/config.hpp"
+#include "util/throw_if.hpp"
 
 namespace path {
 
@@ -28,4 +29,28 @@ std::vector<std::string> recursive_scan_directory( std::string const &scanning_p
   return paths;
 }
 
-}  // path
+void recursive_scan_directory( path::branch const &scanning_path, std::vector<path::branch> &branches ) {
+  for ( const auto &entry :
+        std::filesystem::directory_iterator( static_cast<std::filesystem::path>( scanning_path ) ) ) {
+    branches.emplace_back( entry.path().string() );
+    if ( std::filesystem::is_directory( entry ) ) {
+      recursive_scan_directory( entry.path().string(), branches );
+    }
+  }
+}
+
+std::vector<path::branch> recursive_scan_directory( path::branch const &scanning_path ) {
+  std::vector<path::branch> branches;
+
+  for ( const auto &entry :
+        std::filesystem::directory_iterator( static_cast<std::filesystem::path>( scanning_path ) ) ) {
+    branches.emplace_back( entry.path().string() );
+    if ( std::filesystem::is_directory( entry ) ) {
+      recursive_scan_directory( entry.path().string(), branches );
+    }
+  }
+
+  return branches;
+}
+
+}  // namespace path


### PR DESCRIPTION
# English
I  implemented recursive_scan_directory that, when given a path::branch class, returns the results as std::vector<path::branch>.

# Japanese( Original )
path::branchクラスを与えると、結果のリストをstd::vector<path::branch>型で返すようなrecursive_scan_directoryを実装した。