### PR TITLE
Specification change - to specify the project name and automatically make directory named it

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -16,6 +16,9 @@
 int main( int const argc, char const *argv[] ) {
   int return_value = 0;
   try {
+    util::throw_if<std::invalid_argument>( argc < 2, "please specify the project name" );
+    path::branch project_name( argv[1] );
+
     // スケルトンプログラムを保管しているディレクトリを設定する。
     char const *environment_variable = std::getenv( GET_ENVIRONMENT_VARIABLE );
     util::throw_if<std::runtime_error>(
@@ -48,6 +51,7 @@ int main( int const argc, char const *argv[] ) {
       return is_member_of_ignore_list;
     };
 
+    std::filesystem::create_directory( static_cast<std::filesystem::path>( path::branch( "./" ) + project_name ) );
     for ( decltype( original_branches )::const_iterator citr = original_branches.cbegin();
           citr != original_branches.end(); ++citr ) {
       if ( ignore_branch( *citr ) ) {
@@ -58,7 +62,7 @@ int main( int const argc, char const *argv[] ) {
       path::branch original_branch = *citr;
 
       original_branch.truncate( skeleton_dir );
-      dest_name += original_branch;
+      dest_name += project_name + original_branch;
 
       source_to_dest.emplace_back( *citr, dest_name );
     }


### PR DESCRIPTION
# English
## Background
Previously, the software did not automatically create a directory with the project name. As a result, users had to manually create a directory named after the project, move to that directory, and then execute crep. This workflow was quite cumbersome.

## Change point
If you pass the project name as a command-line argument, this software will create a directory with that project name in the current directory and copy the template into it.

# Japanese( Original )
## 背景
今までは、プロジェクト名を持ったディレクトリを自動的に作ってくれなかった。そのため、プロジェクトディレクトリを作って、そのディレクトリに移動した後でcrepを実行する必要があった。それはとても面倒だった。

## 変更点
コマンドライン引数にプロジェクト名を渡されると、カレントディレクトリにプロジェクトディレクトリを作って、その中にテンプレートをコピーするようにした。