### PR TITLE
Feature/some templates

### DIFF
--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -70,7 +70,7 @@ STATIC_CONSTEXPR crep::character::character_list invalid_character_list(
 );
 #elif __linux__
 STATIC_CONSTEXPR char const *GET_ENVIRONMENT_VARIABLE = "HOME";
-STATIC_CONSTEXPR char const *APPEND_DIRECTORY = "/.config/crep/.cpp_skeleton";
+STATIC_CONSTEXPR char const *APPEND_DIRECTORY = "/.config/crep/template";
 STATIC_CONSTEXPR char const DELIMITER = '/';
 STATIC_CONSTEXPR crep::character::character_list invalid_character_list( { '\\', '\0' } );
 #endif

--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -74,3 +74,5 @@ STATIC_CONSTEXPR char const *APPEND_DIRECTORY = "/.config/crep/template";
 STATIC_CONSTEXPR char const DELIMITER = '/';
 STATIC_CONSTEXPR crep::character::character_list invalid_character_list( { '\\', '\0' } );
 #endif
+
+STATIC_CONSTEXPR char const *DEFAULT_TEMPLATE = "cpp";

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -44,7 +44,7 @@ public:
   using const_reverse_iterator = container_type::const_reverse_iterator;
   using index_type = crep::index_t<container_type::size_type>;
 
-  explicit branch() = delete;
+  explicit branch() = default;
   branch( std::string const & );
   branch( branch const & ) = default;
   branch &operator=( branch const & ) = default;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -19,7 +19,7 @@ int main( int const argc, char const *argv[] ) {
     crep::throw_if<std::invalid_argument>( argc < 2, "please specify the project name" );
     crep::path::branch project_name( argv[1] );
 
-    // スケルトンプログラムを保管しているディレクトリを設定する。
+    // テンプレートを保管しているディレクトリを設定する。
     char const *environment_variable = std::getenv( GET_ENVIRONMENT_VARIABLE );
     crep::throw_if<std::runtime_error>(
         environment_variable == nullptr, std::string( "The environment variable " ) +

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -17,6 +17,12 @@ int main( int const argc, char const *argv[] ) {
   int return_value = 0;
   try {
     crep::throw_if<std::invalid_argument>( argc < 2, "please specify the project name" );
+
+    crep::path::branch template_name( argc >= 3 ? argv[2] : "cpp" );
+    if ( argc < 3 ) {
+      std::cout << "The third argument was not specified. The default, cpp, will be used." << std::endl;
+    }
+
     crep::path::branch project_name( argv[1] );
 
     // テンプレートを保管しているディレクトリを設定する。
@@ -28,6 +34,7 @@ int main( int const argc, char const *argv[] ) {
     );
 
     crep::path::branch skeleton_dir( std::string( environment_variable ) + std::string( APPEND_DIRECTORY ) );
+    skeleton_dir += template_name;
     crep::throw_if<std::runtime_error>(
         !std::filesystem::is_directory( skeleton_dir.to_string() ),
         std::string( "There is NOT project skeleton in " ) + skeleton_dir.to_string()

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -18,7 +18,7 @@ int main( int const argc, char const *argv[] ) {
   try {
     crep::throw_if<std::invalid_argument>( argc < 2, "please specify the project name" );
 
-    crep::path::branch template_name( argc >= 3 ? argv[2] : "cpp" );
+    crep::path::branch template_name( argc >= 3 ? argv[2] : DEFAULT_TEMPLATE );
     if ( argc < 3 ) {
       std::cout << "The third argument was not specified. The default, cpp, will be used." << std::endl;
     }


### PR DESCRIPTION
# English
## Background
Until now, users couldn't specify the template they wanted to use.

## Changing point
1. I modified the name of the directory where available templates are stored.
2. I modified this tool so user can switch to the desired template by using the second argument.

# 日本語( Original )
## 背景
これまで、ユーザが使いたいテンプレートを指定することはできなかった。

## 変更点
1. 利用可能なテンプレートの保存ディレクトリの名前を変更した。
2. 第2引数に与えたテンプレート名を使えるようにした。