### PR TITLE
bugfix - the directory of template directory on Windows was wrong

### DIFF
--- a/include/config/config.hpp
+++ b/include/config/config.hpp
@@ -25,7 +25,7 @@
 
 #ifdef _WIN32
 STATIC_CONSTEXPR char const *GET_ENVIRONMENT_VARIABLE = "LocalAppData";
-STATIC_CONSTEXPR char const *APPEND_DIRECTORY = "\\crep\\.cpp_skeleton";
+STATIC_CONSTEXPR char const *APPEND_DIRECTORY = "\\crep\\template";
 STATIC_CONSTEXPR char const DELIMITER = '\\';
 STATIC_CONSTEXPR crep::character::character_list invalid_character_list(
     { static_cast<char>( 1 ),


### PR DESCRIPTION
# English
## Background
I forgot to update the string representing directory name to store the templates for Windows.

## Bugfix
I fixed the string that represents the template directory enabled when compile on Windows.

# 日本語（ Original ）
## 背景
Windows上で使われる、テンプレートを保存しておくためのディレクトリを表した文字列を変更し忘れていた。

## 修正点
Windows上でコンパイルするときに有効となる、テンプレートディレクトリを表すための文字列を変更した。
