### PR TITLE
Feature/branch move

### DIFF
--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -51,8 +51,9 @@ public:
   branch( branch &&rhs ) noexcept { *this = std::move( rhs ); }
   branch &operator=( branch &&rhs ) noexcept {
     if ( this != &rhs ) {
-      path_element_.clear();
-      if ( rhs.size() != 0 ) {
+      if ( rhs.size() == 0 ) {
+        path_element_.clear();
+      } else {
         path_element_ = std::move( rhs.path_element_ );
       }
     }

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -48,12 +48,13 @@ public:
   branch( std::string const & );
   branch( branch const & ) = default;
   branch &operator=( branch const & ) = default;
-  branch( branch && rhs ) noexcept { *this = std::move( rhs ); }
-  branch &operator=( branch && rhs ) noexcept {
-    if ( rhs.size() == 0 ) {
+  branch( branch &&rhs ) noexcept { *this = std::move( rhs ); }
+  branch &operator=( branch &&rhs ) noexcept {
+    if ( this != &rhs ) {
       path_element_.clear();
-    } else {
-      path_element_ = std::move( rhs.path_element_ );
+      if ( rhs.size() != 0 ) {
+        path_element_ = std::move( rhs.path_element_ );
+      }
     }
     return *this;
   }

--- a/include/path/branch.hpp
+++ b/include/path/branch.hpp
@@ -48,8 +48,15 @@ public:
   branch( std::string const & );
   branch( branch const & ) = default;
   branch &operator=( branch const & ) = default;
-  branch( branch && ) noexcept = default;
-  branch &operator=( branch && ) noexcept = default;
+  branch( branch && rhs ) noexcept { *this = std::move( rhs ); }
+  branch &operator=( branch && rhs ) noexcept {
+    if ( rhs.size() == 0 ) {
+      path_element_.clear();
+    } else {
+      path_element_ = std::move( rhs.path_element_ );
+    }
+    return *this;
+  }
   ~branch() = default;
 
   // [[deprecated]] void modify( std::function<void( std::string & )> );

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -227,4 +227,34 @@ BOOST_AUTO_TEST_CASE( test_case6_not_contain ) {
   TEST( static_cast<size_type>( b.contains( branch( "not_contain" ) ) ) == crep::npos_v<size_type> );
 }
 
+BOOST_AUTO_TEST_CASE( test_branch_move_construct ) {
+  using namespace crep::path;
+  INDICATE_TEST_CASE
+
+  std::vector<std::string> correct_branches = { BRANCH_LIST };
+  std::string test_path = TEST_ABSOLUTE_PATH;
+  branch branch_string( test_path );
+  branch moved_branch;
+
+  auto container_test = []( auto const &target, auto const &correct ) constexpr -> void {
+    TEST( target.size() == correct.size() );
+    for ( auto [target_itr, correct_itr] = std::pair{ target.cbegin(), correct.cbegin() }; target_itr != target.cend();
+          ++target_itr, ++correct_itr ) {
+      std::cout << "*target_itr: " << *target_itr << std::endl;
+      std::cout << "*correct_itr: " << *correct_itr << std::endl;
+      TEST( *target_itr == *correct_itr );
+    }
+  };
+
+  moved_branch = std::move( branch_string );
+  container_test( moved_branch, correct_branches );
+
+  std::cout << std::endl;
+  branch moved_branch_ctor( branch( TEST_ABSOLUTE_PATH ) );
+  container_test( moved_branch_ctor, correct_branches );
+
+  moved_branch = branch( "" );
+  TEST( moved_branch.size() == 0 );
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -26,6 +26,21 @@
 #  define BRANCH_LIST "/", "usr", "include", "c++", "11", "cstdlib"
 #endif
 
+namespace crep::test {
+
+auto container_test = []( auto const &target, auto const &correct ) constexpr -> void {
+  TEST( target.size() == correct.size() );
+
+  for ( auto [target_itr, correct_itr] = std::pair{ target.cbegin(), correct.cbegin() }; target_itr != target.cend();
+        ++target_itr, ++correct_itr ) {
+    std::cout << "*target_itr: " << *target_itr << std::endl;
+    std::cout << "*correct_itr: " << *correct_itr << std::endl;
+    TEST( *target_itr == *correct_itr );
+  }
+};
+
+}  // namespace crep::test
+
 BOOST_AUTO_TEST_SUITE( test_branch )
 
 BOOST_AUTO_TEST_CASE( test_case1 ) {
@@ -236,22 +251,12 @@ BOOST_AUTO_TEST_CASE( test_branch_move_construct ) {
   branch branch_string( test_path );
   branch moved_branch;
 
-  auto container_test = []( auto const &target, auto const &correct ) constexpr -> void {
-    TEST( target.size() == correct.size() );
-    for ( auto [target_itr, correct_itr] = std::pair{ target.cbegin(), correct.cbegin() }; target_itr != target.cend();
-          ++target_itr, ++correct_itr ) {
-      std::cout << "*target_itr: " << *target_itr << std::endl;
-      std::cout << "*correct_itr: " << *correct_itr << std::endl;
-      TEST( *target_itr == *correct_itr );
-    }
-  };
-
   moved_branch = std::move( branch_string );
-  container_test( moved_branch, correct_branches );
+  crep::test::container_test( moved_branch, correct_branches );
 
   std::cout << std::endl;
   branch moved_branch_ctor( branch( TEST_ABSOLUTE_PATH ) );
-  container_test( moved_branch_ctor, correct_branches );
+  crep::test::container_test( moved_branch_ctor, correct_branches );
 
   moved_branch = branch( "" );
   TEST( moved_branch.size() == 0 );

--- a/test/path/branch.cpp
+++ b/test/path/branch.cpp
@@ -11,6 +11,8 @@
 #include "iterator/index_t.hpp"
 
 #define TEST( CONDITION ) BOOST_TEST( ( CONDITION ) == true )
+#define INDICATE_TEST_CASE \
+  std::cout << "======== " << boost::unit_test::framework::current_test_case().p_name << " ========" << std::endl;
 
 #if _WIN32
 #  define TEST_ABSOLUTE_PATH "C:\\Users\\username\\AppData\\Local\\nvim\\init.lua"


### PR DESCRIPTION
# English
## Background
Until now, the implementation of the branch class had the following two problems:
1. (To be exact,) there was unnecessary process.
2. Move assignment might not have been called.

### Detail
#### 1 unnecessary process
In the move assignment operator for vector, all its own elements are first cleared, and then all elements from the other vector(rhs) are moved. Therefore, when the source vector has no elements, there might be a redundant process: The delete is necessary, however, the next move operation is not necessary. In practice, compilers might optimize the redundant process. Although it's beneficial when they do, I think that C++ programmers, who enjoy a high degree of programming freedom, shouldn't rely on the compiler for such optimizations.

#### 2 uncalled move assignment
In the definition of the move constructor and move assignment operator, the other branch is treated as an lvalue. Therefore, if they are defaulted, the copy assignment operator of std::vector might be invoked. This means that even though programmers intend to move, it may actually result in a copy. This behavior is not what programmers desire. Therefore, it's better for programmers to define the move constructor and move assignment operator explicitly, not just declare them.

## Modification
1. When the size of the rhs is 0, only the clear function is called.
2. Cast path_element_ to an rvalue to ensure the move assignment operator is invoked.

# 日本語（ Original ）
## 背景
今までのbranchクラスの実装では、以下2点の問題があった。
1. （厳密に言えば）不要な処理があった。
2. ムーブ代入が行われていなかった（かもしれない）。

### 詳細
#### 1 不要な処理
vectorのムーブ代入演算子では、自身のすべての要素が開放された後に、相手側のすべての要素がムーブされるという仕様になっている。そのため、ムーブ元の要素数が0だった場合は、厳密には不要な処理（要素の開放は必要だが、その直後のムーブは不要）が行われることとなっていた（実際にはコンパイラによって、そのような不要な処理は簡略化されるのかもしれない。もちろん、簡略化してくれるに越したことはない。しかし自由度の高いプログラミングを許可されているC++プログラマであれば、そこまでの最適化をコンパイラに頼るべきではないように感じる）。

#### 2 ムーブ代入
ムーブコンストラクタおよびムーブ代入演算子の中では、相手のbranchは左辺値となっている。そのため、ムーブの定義中では、（ムーブそれぞれがdefault指定されていた場合、）std::vectorのコピー代入演算子が呼び出されることとなる。つまり、（今まではdefault指定だったため、コンパイラがどのようなムーブコンストラクタとムーブ代入演算子を生成していたのかは分からないが、）ムーブしているつもりが、実際にはコピーになっていた（かもしれない）。それはプログラマが望んでいる動作ではない。そのため、ムーブコンストラクタとムーブ代入演算子はプログラマが明示的に（宣言するだけでなく、）定義した方が良いだろう。

## 修正点
1. ムーブ元のsize()が0だったら、clear関数を呼び出すだけにする。
2. ムーブ元のpath_element_を右辺値にキャストし、ムーブ代入演算子が呼び出されるようにする。